### PR TITLE
Use fixed Commander version (cannot find module)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Command-line interface to underscore.js - useful for shell scripting and JSON processing",
   "version": "0.2.17",
   "contributors": ["Dave Dopson <ddopson@gmail.com>"],
-  "dependencies": { "underscore": ">= 1.3.3", "underscore.string": "*", "commander": "*" },
+  "dependencies": { "underscore": ">= 1.3.3", "underscore.string": "*", "commander": "1.0.5" },
   "optionalDependencies": { "coffee-script": "*", "JSONSelect": "*", "msgpack": "*" },
   "devDependencies": { "mocha": "*" },
   "main": "index.js",


### PR DESCRIPTION
The newer version that is installed with \* in `package.json` breaks `map`, `reduce` and other commands. Using the version specified in @ddopson info in README fixes the issue.

Fixes #26 & #28.
