### PR TITLE
Remove process.exit() after outputData

### DIFF
--- a/bin/underscore
+++ b/bin/underscore
@@ -888,7 +888,6 @@ function processData(fn) {
       process.exit(-1);
     }
     outputData(output);
-    process.exit(0);
   });
 }
 


### PR DESCRIPTION
Because outputData() can be async, the process can exit before having
the time to output the whole json

I sometimes had an issue where  `node bin/underscore print -i test.json` would not print all lines of the json but stop in the middle. I think this is due to the write not being totally synchronous when the data is huge, and so it was exiting prematurely.

This commit fixes the bug