### PR TITLE
Add --indent commandline option

### DIFF
--- a/bin/underscore
+++ b/bin/underscore
@@ -37,6 +37,7 @@ function addStandardOptions(command) {
     .option('--text', "Parse data as text instead of JSON. Sets input and output formats to 'text'")
     .option('--trace', "Print stack traces when things go wrong")
     .option('--wrapwidth <width>', "Modify line-wrap width")
+    .option('--indent <width>', "Modify indentation width")
 }
 
 program.defaultInputFormat = 'lax';
@@ -1051,6 +1052,11 @@ function outputData(data) {
 
     if (program.wrapwidth && typeof formatter.withConfig == 'function') {
       formatter = formatter.withConfig({wrapWidth: program.wrapwidth});
+    }
+
+    if (program.indent && typeof formatter.withConfig == 'function') {
+      var indentString = ' '.repeat(program.indent);
+      formatter = formatter.withConfig({indent: indentString});
     }
     
     var output;


### PR DESCRIPTION
Added option for specifying indentation width.
I'm using underscore-cli for json files formatting in the scripts at my work. It's a very good tool, but unfortunately our codestyle requires indentation in 4 spaces, and now no way how to specify it.
